### PR TITLE
fix: truly removed stretch problem caused by edit text

### DIFF
--- a/src/components/ImageCard.tsx
+++ b/src/components/ImageCard.tsx
@@ -186,7 +186,7 @@ export default function ImageCard({ ImageUrl, className }: ImageCardProps) {
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <p
-                          className="ellipsis truncate"
+                          className="max-w-[19ch] ellipsis truncate overflow-hidden"
                           onDoubleClick={handleEditClick}
                         >
                           {content}


### PR DESCRIPTION
# removed stretch problem truly now
## before
![image](https://github.com/user-attachments/assets/a996817d-432e-4fed-bb66-023309158dc9)
## after
![image](https://github.com/user-attachments/assets/12e7544e-21c9-4c75-b17b-e2dc827a2862)
